### PR TITLE
Casminst 3857

### DIFF
--- a/kubernetes/cray-ceph-csi-cephfs/Chart.yaml
+++ b/kubernetes/cray-ceph-csi-cephfs/Chart.yaml
@@ -8,12 +8,12 @@ keywords:
   - ceph-csi
 home: https://github.com/Cray-HPE/cray-ceph-csi-cephfs
 sources:
-  - https://github.com/ceph/ceph-csi/tree/v3.4.0/charts/ceph-csi-cephfs
+  - https://github.com/ceph/ceph-csi/tree/v3.5.1/charts/ceph-csi-cephfs
 dependencies:
   - name: ceph-csi-cephfs
     version: 3.5.1
     repository: https://ceph.github.io/csi-charts
 maintainers:
   - name: bklei
-icon: https://raw.githubusercontent.com/ceph/ceph-csi/v3.4.0/assets/ceph-logo.png
+icon: https://raw.githubusercontent.com/ceph/ceph-csi/v3.5.1/assets/ceph-logo.png
 appVersion: 3.5.1

--- a/kubernetes/cray-ceph-csi-cephfs/Chart.yaml
+++ b/kubernetes/cray-ceph-csi-cephfs/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-ceph-csi-cephfs
-version: 3.4.0
+version: 3.5.1
 description: Container Storage Interface (CSI) driver, provisioner, snapshotter and attacher for Ceph cephfs
 keywords:
   - ceph
@@ -11,9 +11,9 @@ sources:
   - https://github.com/ceph/ceph-csi/tree/v3.4.0/charts/ceph-csi-cephfs
 dependencies:
   - name: ceph-csi-cephfs
-    version: 3.4.0
+    version: 3.5.1
     repository: https://ceph.github.io/csi-charts
 maintainers:
   - name: bklei
 icon: https://raw.githubusercontent.com/ceph/ceph-csi/v3.4.0/assets/ceph-logo.png
-appVersion: 3.4.0
+appVersion: 3.5.1

--- a/kubernetes/cray-ceph-csi-cephfs/templates/ceph-csi-job-perms.yaml
+++ b/kubernetes/cray-ceph-csi-cephfs/templates/ceph-csi-job-perms.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:ceph-csi-cephfs-role
+rules:
+- apiGroups:
+  - "apps"
+  resources:
+  - pods
+  - nodes
+  - nodes/stats
+  - namespaces
+  - configmaps
+  - replicasets
+  - storageclasses
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - "storage.k8s.io"
+  resources:
+  - storageclasses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:ceph-csi-cephfs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:ceph-csi-cephfs-role
+subjects:
+- kind: ServiceAccount
+  name: ceph-csi-sa
+  namespace: ceph-cephfs
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ceph-csi-sa
+  namespace: ceph-cephfs
+  labels:
+    app: ceph-csi
+

--- a/kubernetes/cray-ceph-csi-cephfs/values.yaml
+++ b/kubernetes/cray-ceph-csi-cephfs/values.yaml
@@ -86,7 +86,7 @@ ceph-csi-cephfs:
 
     registrar:
       image:
-        repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+        repository: artifactory.algol60.net/k8s.gcr.io/sig-storage/csi-node-driver-registrar
         tag: v2.4.0
         pullPolicy: IfNotPresent
       resources: {}
@@ -162,7 +162,7 @@ ceph-csi-cephfs:
 
     provisioner:
       image:
-        repository: k8s.gcr.io/sig-storage/csi-provisioner
+        repository: artifactory.algol60.net/k8s.gcr.io/sig-storage/csi-provisioner
         tag: v3.1.0
         pullPolicy: IfNotPresent
       resources: {}
@@ -171,7 +171,7 @@ ceph-csi-cephfs:
       name: attacher
       enabled: true
       image:
-        repository: k8s.gcr.io/sig-storage/csi-attacher
+        repository: artifactory.algol60.net/k8s.gcr.io/sig-storage/csi-attacher
         tag: v3.4.0
         pullPolicy: IfNotPresent
       resources: {}
@@ -180,14 +180,14 @@ ceph-csi-cephfs:
       name: resizer
       enabled: true
       image:
-        repository: k8s.gcr.io/sig-storage/csi-resizer
+        repository: artifactory.algol60.net/k8s.gcr.io/sig-storage/csi-resizer
         tag: v1.3.0
         pullPolicy: IfNotPresent
       resources: {}
 
     snapshotter:
       image:
-        repository: k8s.gcr.io/sig-storage/csi-snapshotter
+        repository: artifactory.algol60.net/k8s.gcr.io/sig-storage/csi-snapshotter
         tag: v4.2.0
         pullPolicy: IfNotPresent
       resources: {}

--- a/kubernetes/cray-ceph-csi-cephfs/values.yaml
+++ b/kubernetes/cray-ceph-csi-cephfs/values.yaml
@@ -87,7 +87,7 @@ ceph-csi-cephfs:
     registrar:
       image:
         repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-        tag: v2.2.0
+        tag: v2.4.0
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -96,7 +96,7 @@ ceph-csi-cephfs:
         # XXX quay.io/cephcsi/cephcsi:v3.4.0 has 4 critical (of 8)
         # XXX vulnerabilities, so we're rebuilding it to resolve them.
         repository: artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi
-        tag: v3.4.0
+        tag: v3.5.1
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -163,7 +163,7 @@ ceph-csi-cephfs:
     provisioner:
       image:
         repository: k8s.gcr.io/sig-storage/csi-provisioner
-        tag: v2.2.2
+        tag: v3.1.0
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -172,7 +172,7 @@ ceph-csi-cephfs:
       enabled: true
       image:
         repository: k8s.gcr.io/sig-storage/csi-attacher
-        tag: v3.2.1
+        tag: v3.4.0
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -181,14 +181,14 @@ ceph-csi-cephfs:
       enabled: true
       image:
         repository: k8s.gcr.io/sig-storage/csi-resizer
-        tag: v1.2.0
+        tag: v1.3.0
         pullPolicy: IfNotPresent
       resources: {}
 
     snapshotter:
       image:
         repository: k8s.gcr.io/sig-storage/csi-snapshotter
-        tag: v4.1.1
+        tag: v4.2.0
         pullPolicy: IfNotPresent
       resources: {}
 

--- a/kubernetes/cray-ceph-csi-cephfs/values.yaml
+++ b/kubernetes/cray-ceph-csi-cephfs/values.yaml
@@ -11,18 +11,18 @@ ceph-csi-cephfs:
 
   rbac:
     # Specifies whether RBAC resources should be created
-    create: false
+    create: true
 
   serviceAccounts:
     nodeplugin:
       # Specifies whether a ServiceAccount should be created
-      create: false
+      create: true
       # The name of the ServiceAccount to use.
       # If not set and create is true, a name is generated using the fullname
       name: "cray-node-plugin-serviceaccount"
     provisioner:
       # Specifies whether a ServiceAccount should be created
-      create: false
+      create: true
       # The name of the ServiceAccount to use.
       # If not set and create is true, a name is generated using the fullname
       name: "cray-csi-serviceaccount"

--- a/kubernetes/cray-ceph-csi-cephfs/values.yaml
+++ b/kubernetes/cray-ceph-csi-cephfs/values.yaml
@@ -120,7 +120,11 @@ ceph-csi-cephfs:
     replicaCount: 3
     # Timeout for waiting for creation or deletion of a volume
     timeout: 60s
-
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 50%
+  
     # set user created priorityclassName for csi provisioner pods. default is
     # system-cluster-critical which is less priority than system-node-critical
     priorityClassName: csm-high-priority-service


### PR DESCRIPTION
## Summary and Scope

This is a newer ceph-csi chart that supports setting the upgrade strategy.  Currently the defaults used by the chart are not setup to work with a 3 worker system.

## Issues and Related PRs

* Resolves CASMINST-3857

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Install cephfs/rbd csi 3.4.0 charts.  create deployment/statefulsets for rbd and cephfs pvcs.  upgrade to ceph-csi 3.5.1 moving them from the default namespace into ceph-rbd/ceph-cephfs.  verfiy pods w/ pvcs are still functional.  Move the pods to ensure pvc migration and verify testfiles are intact.  

Test the reverse of this for downgrades

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This will require a brief outage during the upgrade where pods with pvcs will not be able to move.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

