### PR TITLE
Add missing parms to cephfs storage class with sp3 image (CASMPET-6471)

### DIFF
--- a/kubernetes/cray-ceph-csi-cephfs/Chart.yaml
+++ b/kubernetes/cray-ceph-csi-cephfs/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-ceph-csi-cephfs
-version: 3.6.2
+version: 3.6.3
 description: Container Storage Interface (CSI) driver, provisioner, snapshotter and attacher for Ceph cephfs
 keywords:
   - ceph

--- a/kubernetes/cray-ceph-csi-cephfs/templates/post-install.yaml
+++ b/kubernetes/cray-ceph-csi-cephfs/templates/post-install.yaml
@@ -29,10 +29,18 @@ spec:
           image: {{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}
           imagePullPolicy: {{ .Values.kubectl.image.pullPolicy }}
           command:
-            - bin/sh
-            - -c
+            - '/bin/sh'
+          args:
+            - "-c"
             - |
-              kubectl apply -f /apps/storage_classes/sc-cephfs.yaml
+              cp /apps/storage_classes/sc-cephfs.yaml /tmp/sc-cephfs.yaml
+              if ! grep -q provisioner-secret-name /tmp/sc-cephfs.yaml; then
+                echo "Adding ceph secret parameters to cephfs storage class."
+                sed -i '/parameters:/a \   csi.storage.k8s.io/provisioner-secret-name: csi-cephfs-secret\n   csi.storage.k8s.io/provisioner-secret-namespace: default\n   csi.storage.k8s.io/controller-expand-secret-name: csi-cephfs-secret\n   csi.storage.k8s.io/controller-expand-secret-namespace: default\n   csi.storage.k8s.io/node-stage-secret-name: csi-cephfs-secret\n   csi.storage.k8s.io/node-stage-secret-namespace: default' /tmp/sc-cephfs.yaml
+              else
+                echo "cephfs storage class contains provisioner-secret-name -- proceeding."
+              fi
+              kubectl apply -f /tmp/sc-cephfs.yaml
           volumeMounts:
             - name: cephfs-csi-sc-vol
               mountPath: /apps/storage_classes/sc-cephfs.yaml

--- a/kubernetes/cray-ceph-csi-cephfs/values.yaml
+++ b/kubernetes/cray-ceph-csi-cephfs/values.yaml
@@ -124,7 +124,7 @@ ceph-csi-cephfs:
       type: RollingUpdate
       rollingUpdate:
         maxUnavailable: 50%
-  
+
     # set user created priorityclassName for csi provisioner pods. default is
     # system-cluster-critical which is less priority than system-node-critical
     priorityClassName: csm-high-priority-service


### PR DESCRIPTION
### Summary and Scope

Add missing parms to cephfs storage class with sp3 image

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6471

### Testing

* `vex`

```
pit:~ # kubectl get sc ceph-cephfs-external -o yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"storage.k8s.io/v1","kind":"StorageClass","metadata":{"annotations":{},"name":"ceph-cephfs-external"},"parameters":{"clusterID":"e1b63294-d356-11ed-a56f-42010afc0104","csi.storage.k8s.io/controller-expand-secret-name":"csi-cephfs-secret","csi.storage.k8s.io/controller-expand-secret-namespace":"default","csi.storage.k8s.io/node-stage-secret-name":"csi-cephfs-secret","csi.storage.k8s.io/node-stage-secret-namespace":"default","csi.storage.k8s.io/provisioner-secret-name":"csi-cephfs-secret","csi.storage.k8s.io/provisioner-secret-namespace":"default","fsName":"cephfs","pool":"cephfs.cephfs.data"},"provisioner":"cephfs.csi.ceph.com"}
  creationTimestamp: "2023-04-05T18:31:25Z"
  name: ceph-cephfs-external
  resourceVersion: "839435"
  uid: 6745e47a-8665-455b-bcfb-1e193c274769
parameters:
  clusterID: e1b63294-d356-11ed-a56f-42010afc0104
  csi.storage.k8s.io/controller-expand-secret-name: csi-cephfs-secret
  csi.storage.k8s.io/controller-expand-secret-namespace: default
  csi.storage.k8s.io/node-stage-secret-name: csi-cephfs-secret
  csi.storage.k8s.io/node-stage-secret-namespace: default
  csi.storage.k8s.io/provisioner-secret-name: csi-cephfs-secret
  csi.storage.k8s.io/provisioner-secret-namespace: default
  fsName: cephfs
  pool: cephfs.cephfs.data
provisioner: cephfs.csi.ceph.com
reclaimPolicy: Delete
volumeBindingMode: Immediate
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
