### PR TITLE
CASMPET-7221 update docker-kubectl version to 1.24.17

### DIFF
--- a/kubernetes/cray-ceph-csi-cephfs/Chart.yaml
+++ b/kubernetes/cray-ceph-csi-cephfs/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-ceph-csi-cephfs
-version: 3.6.3
+version: 3.6.3-1
 description: Container Storage Interface (CSI) driver, provisioner, snapshotter and attacher for Ceph cephfs
 keywords:
   - ceph

--- a/kubernetes/cray-ceph-csi-cephfs/values.yaml
+++ b/kubernetes/cray-ceph-csi-cephfs/values.yaml
@@ -1,7 +1,7 @@
 kubectl:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-    tag: 1.21.12
+    tag: 1.24.17
     pullPolicy: IfNotPresent
 
 ceph-csi-cephfs:


### PR DESCRIPTION
## Summary and Scope

For k8s 1.24 in CSM 1.6, the docker-kubectl container image should be updated so that it is using version 1.24.17.

## Issues and Related PRs

* Relates to [CASMPET-7221](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7221)

## Testing

### Tested on:

  * Beau, vshasta2

### Test description:

I tested an upgrade and install of the chart. I observed that the `post-install.yaml` template that uses this container image worked correctly.

```
cephfs storage class contains provisioner-secret-name -- proceeding.
storageclass.storage.k8s.io/ceph-cephfs-external configured
```

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

