### PR TITLE
CASMPET-7300: Upgrade to cephcsi v3.14.0

### DIFF
--- a/kubernetes/cray-ceph-csi-cephfs/Chart.yaml
+++ b/kubernetes/cray-ceph-csi-cephfs/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-ceph-csi-cephfs
-version: 3.13.0
+version: 3.14.0
 description: Container Storage Interface (CSI) driver, provisioner, snapshotter and attacher for Ceph cephfs
 keywords:
   - ceph
@@ -8,12 +8,12 @@ keywords:
   - ceph-csi
 home: https://github.com/Cray-HPE/cray-ceph-csi-cephfs
 sources:
-  - https://github.com/ceph/ceph-csi/tree/v3.13.0/charts/ceph-csi-cephfs
+  - https://github.com/ceph/ceph-csi/tree/v3.14.0/charts/ceph-csi-cephfs
 dependencies:
   - name: ceph-csi-cephfs
-    version: 3.13.0
+    version: 3.14.0
     repository: https://ceph.github.io/csi-charts
 maintainers:
   - name: bklei
-icon: https://raw.githubusercontent.com/ceph/ceph-csi/v3.13.0/assets/ceph-logo.png
-appVersion: 3.13.0
+icon: https://raw.githubusercontent.com/ceph/ceph-csi/v3.14.0/assets/ceph-logo.png
+appVersion: 3.14.0

--- a/kubernetes/cray-ceph-csi-cephfs/Chart.yaml
+++ b/kubernetes/cray-ceph-csi-cephfs/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-ceph-csi-cephfs
-version: 3.6.3-1
+version: 3.13.0
 description: Container Storage Interface (CSI) driver, provisioner, snapshotter and attacher for Ceph cephfs
 keywords:
   - ceph
@@ -8,12 +8,12 @@ keywords:
   - ceph-csi
 home: https://github.com/Cray-HPE/cray-ceph-csi-cephfs
 sources:
-  - https://github.com/ceph/ceph-csi/tree/v3.5.1/charts/ceph-csi-cephfs
+  - https://github.com/ceph/ceph-csi/tree/v3.13.0/charts/ceph-csi-cephfs
 dependencies:
   - name: ceph-csi-cephfs
-    version: 3.6.2
+    version: 3.13.0
     repository: https://ceph.github.io/csi-charts
 maintainers:
   - name: bklei
-icon: https://raw.githubusercontent.com/ceph/ceph-csi/v3.5.1/assets/ceph-logo.png
-appVersion: 3.6.2
+icon: https://raw.githubusercontent.com/ceph/ceph-csi/v3.13.0/assets/ceph-logo.png
+appVersion: 3.13.0

--- a/kubernetes/cray-ceph-csi-cephfs/values.yaml
+++ b/kubernetes/cray-ceph-csi-cephfs/values.yaml
@@ -86,8 +86,8 @@ ceph-csi-cephfs:
 
     registrar:
       image:
-        repository: artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-node-driver-registrar
-        tag: v2.4.0
+        repository: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-node-driver-registrar
+        tag: v2.9.0
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -96,7 +96,7 @@ ceph-csi-cephfs:
         # XXX quay.io/cephcsi/cephcsi:v3.4.0 has 4 critical (of 8)
         # XXX vulnerabilities, so we're rebuilding it to resolve them.
         repository: artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi
-        tag: v3.6.2
+        tag: v3.13.0
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -162,8 +162,8 @@ ceph-csi-cephfs:
 
     provisioner:
       image:
-        repository: artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner
-        tag: v3.1.0
+        repository: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-provisioner
+        tag: v3.6.0
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -171,8 +171,8 @@ ceph-csi-cephfs:
       name: attacher
       enabled: true
       image:
-        repository: artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-attacher
-        tag: v3.4.0
+        repository: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-attacher
+        tag: v4.4.0
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -180,15 +180,15 @@ ceph-csi-cephfs:
       name: resizer
       enabled: true
       image:
-        repository: artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-resizer
-        tag: v1.4.0
+        repository: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-resizer
+        tag: v1.9.0
         pullPolicy: IfNotPresent
       resources: {}
 
     snapshotter:
       image:
-        repository: artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-snapshotter
-        tag: v4.2.0
+        repository: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-snapshotter
+        tag: v6.2.1
         pullPolicy: IfNotPresent
       resources: {}
 

--- a/kubernetes/cray-ceph-csi-cephfs/values.yaml
+++ b/kubernetes/cray-ceph-csi-cephfs/values.yaml
@@ -43,6 +43,11 @@ ceph-csi-cephfs:
   # Supported values from 0 to 5. 0 for general useful logs,
   # 5 for trace level verbosity.
   logLevel: 0
+  # sidecarLogLevel is the variable for Kubernetes sidecar container's log level
+  sidecarLogLevel: 1
+  # Log slow operations at the specified rate.
+  # Operation is considered slow if it outlives its deadline.
+  logSlowOperationInterval: 30s
 
   nodeplugin:
     name: nodeplugin
@@ -87,7 +92,7 @@ ceph-csi-cephfs:
     registrar:
       image:
         repository: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-node-driver-registrar
-        tag: v2.9.0
+        tag: v2.13.0
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -96,7 +101,7 @@ ceph-csi-cephfs:
         # XXX quay.io/cephcsi/cephcsi:v3.4.0 has 4 critical (of 8)
         # XXX vulnerabilities, so we're rebuilding it to resolve them.
         repository: artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi
-        tag: v3.13.0
+        tag: v3.14.0
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -160,19 +165,13 @@ ceph-csi-cephfs:
         loadBalancerIP: ""
         loadBalancerSourceRanges: []
 
+    profiling:
+      enabled: false
+
     provisioner:
       image:
         repository: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-provisioner
-        tag: v3.6.0
-        pullPolicy: IfNotPresent
-      resources: {}
-
-    attacher:
-      name: attacher
-      enabled: true
-      image:
-        repository: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-attacher
-        tag: v4.4.0
+        tag: v5.2.0
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -181,14 +180,14 @@ ceph-csi-cephfs:
       enabled: true
       image:
         repository: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-resizer
-        tag: v1.9.0
+        tag: v1.13.2
         pullPolicy: IfNotPresent
       resources: {}
 
     snapshotter:
       image:
         repository: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-snapshotter
-        tag: v6.2.1
+        tag: v8.2.1
         pullPolicy: IfNotPresent
       resources: {}
 
@@ -202,18 +201,6 @@ ceph-csi-cephfs:
     # https://kubernetes.io/docs/concepts/policy/pod-security-policy/
     podSecurityPolicy:
       enabled: true
-
-  topology:
-    # Specifies whether topology based provisioning support should
-    # be exposed by CSI
-    enabled: false
-    # domainLabels define which node labels to use as domains
-    # for CSI nodeplugins to advertise their domains
-    # NOTE: the value here serves as an example and needs to be
-    # updated with node labels that define domains of interest
-    domainLabels:
-      - failure-domain/region
-      - failure-domain/zone
 
   #########################################################
   # Variables for 'internal' use please use with caution! #
@@ -233,6 +220,3 @@ ceph-csi-cephfs:
   # configMapKey:
   # Use an externally provided configmap
   externallyManagedConfigmap: true
-
-  # Custom image variables for HPE Cray
-  imagesHost: "dtr.dev.cray.com"


### PR DESCRIPTION
## Summary and Scope

Upgrade cephcsi to the latest v3.14.0 that supports K8s 1.32. The chart should be upgraded only after K8s is upgraded.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7300](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7300)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `beau`
  * Virtual Shasta

### Test description:

After upgrading the chart, created a PVC with cephfs provisioner and verified a pod can be created with the new PVC.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

